### PR TITLE
re-export margined_neutron_std as neutron_std

### DIFF
--- a/packages/neutron-test-tube/src/lib.rs
+++ b/packages/neutron-test-tube/src/lib.rs
@@ -4,7 +4,7 @@ mod module;
 mod runner;
 
 pub use cosmrs;
-pub use margined_neutron_std;
+pub use margined_neutron_std as neutron_std;
 
 pub use module::*;
 pub use runner::app::NeutronTestApp;


### PR DESCRIPTION
I don't think user should care which neutron-std he uses while using neutron-test-tube so let's simplify re-export!